### PR TITLE
additional CSS selector formatting

### DIFF
--- a/lib/syntax_tree/css/format.rb
+++ b/lib/syntax_tree/css/format.rb
@@ -47,6 +47,11 @@ module SyntaxTree
         q.text(node.value)
       end
 
+      # Visit a HashToken node.
+      def visit_hash_token(node)
+        q.text(node.value)
+      end
+
       # Visit a StyleRule node.
       def visit_style_rule(node)
         q.group do
@@ -77,9 +82,27 @@ module SyntaxTree
         end
       end
 
+      # Visit a Selectors::IdSelector node.
+      def visit_id_selector(node)
+        q.text("#")
+        node.value.format(q)
+      end
+
       # Visit a Selectors::ClassSelector node.
       def visit_class_selector(node)
         q.text(".")
+        node.value.format(q)
+      end
+
+      # Visit a Selectors::PseudoClassSelector node.
+      def visit_pseudo_class_selector(node)
+        q.text(":")
+        node.value.format(q)
+      end
+
+      # Visit a Selectors::PseudoElementSelector node.
+      def visit_pseudo_element_selector(node)
+        q.text(":")
         node.value.format(q)
       end
 
@@ -101,9 +124,8 @@ module SyntaxTree
       # Visit a Selectors::CompoundSelector node.
       def visit_compound_selector(node)
         q.group do
-          node.type.format(q) if node.type
-          node.subclasses.each do |subclass|
-            subclass.format(q)
+          node.child_nodes.each do |node_|
+            node_.format(q)
           end
           # TODO: pseudo-elements
         end

--- a/lib/syntax_tree/css/selectors.rb
+++ b/lib/syntax_tree/css/selectors.rb
@@ -125,7 +125,7 @@ module SyntaxTree
         end
 
         def child_nodes
-          [type, subclasses, pseudo_elements].flatten
+          [type, subclasses, pseudo_elements].compact.flatten
         end
 
         alias deconstruct child_nodes

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -72,11 +72,54 @@ module SyntaxTree
                 pseudo_elements: [
                   [
                     Selectors::PseudoElementSelector[
-                      Selectors::PseudoClassSelector[
-                        value: { value: "first-line" }
-                      ]
+                      value: { value: { value: "first-line" } }
                     ],
                     []
+                  ]
+                ]
+              ]
+            ]
+          end
+        end
+
+        it "parses a compound selector with a pseudo-class" do
+          actual = parse_selectors("div.flex:hover")
+
+          assert_pattern do
+            actual => [
+              Selectors::CompoundSelector[
+                type: { value: { name: { value: "div" } } },
+                subclasses: [
+                  Selectors::ClassSelector[value: { value: "flex" }],
+                  Selectors::PseudoClassSelector[value: { value: "hover" }],
+                ],
+              ]
+            ]
+          end
+        end
+
+        it "parses a compound selector with pseudo-elements and pseudo-classes" do
+          actual = parse_selectors("div.flex:hover::first-line:last-child:active::first-letter")
+
+          assert_pattern do
+            actual => [
+              Selectors::CompoundSelector[
+                type: { value: { name: { value: "div" } } },
+                subclasses: [
+                  Selectors::ClassSelector[value: { value: "flex" }],
+                  Selectors::PseudoClassSelector[value: { value: "hover" }],
+                ],
+                pseudo_elements: [
+                  [
+                    Selectors::PseudoElementSelector[value: { value: { value: "first-line" } }],
+                    [
+                      Selectors::PseudoClassSelector[value: { value: "last-child" }],
+                      Selectors::PseudoClassSelector[value: { value: "active" }],
+                    ],
+                  ],
+                  [
+                    Selectors::PseudoElementSelector[value: { value: { value: "first-letter" } }],
+                    [],
                   ]
                 ]
               ]

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -27,6 +27,15 @@ module SyntaxTree
               ]
             ]
           end
+
+          assert_pattern do
+            actual => [
+              Selectors::CompoundSelector[
+                Selectors::ClassSelector[value: { value: "flex" }],
+                Selectors::ClassSelector[value: { value: "text-xl" }]
+              ]
+            ]
+          end
         end
 
         it "parses a compound selector" do
@@ -38,6 +47,15 @@ module SyntaxTree
                 type: { value: { name: { value: "div" } } },
                 subclasses: [Selectors::ClassSelector[value: { value: "flex" }]],
                 pseudo_elements: []
+              ]
+            ]
+          end
+
+          assert_pattern do
+            actual => [
+              Selectors::CompoundSelector[
+                Selectors::TypeSelector[value: { name: { value: "div" } } ],
+                Selectors::ClassSelector[value: { value: "flex" }],
               ]
             ]
           end

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -212,8 +212,43 @@ module SyntaxTree
       end
 
       describe "formatting" do
-        it "formats complex selectors" do
-          assert_selector_format(".outer section.foo>table.bar   tr", ".outer section.foo > table.bar tr")
+        describe Selectors::CompoundSelector do
+          it "with an id selector" do
+            assert_selector_format(
+              "div#foo",
+              "div#foo",
+            )
+          end
+
+          it "with a pseudo-class selector" do
+            assert_selector_format(
+              "div:hover",
+              "div:hover",
+            )
+          end
+
+          it "with class selectors" do
+            assert_selector_format(
+              "div.flex.text-xl",
+              "div.flex.text-xl",
+            )
+          end
+
+          it "with pseudo-elements" do
+            assert_selector_format(
+              "div.flex:hover::first-line:last-child:active::first-letter",
+              "div.flex:hover::first-line:last-child:active::first-letter",
+            )
+          end
+        end
+
+        describe Selectors::ComplexSelector do
+          it "with whitespace" do
+            assert_selector_format(
+              ".outer section.foo>table.bar   tr",
+              ".outer section.foo > table.bar tr",
+            )
+          end
         end
 
         private
@@ -223,7 +258,7 @@ module SyntaxTree
 
           io = StringIO.new
           selectors.each do |selector|
-            selector.format(::PrettyPrint.new(io))
+            selector.format(::PP.new(io))
             assert_equal(expected, io.string)
           end
         end


### PR DESCRIPTION
Implement CSS selector formatting for IdSelector, HashToken, PseudoClassSelector, and PseudoElementSelector, and add test coverage.

Also backfill coverage of the existing PseudoElementSelector AST.
