### PR TITLE
Include an explicit Combinator in the AST for implicit descendant

### DIFF
--- a/lib/syntax_tree/css/format.rb
+++ b/lib/syntax_tree/css/format.rb
@@ -111,6 +111,10 @@ module SyntaxTree
         case node.value
         when WhitespaceToken
           q.text(" ")
+        when Array
+          q.text(" ")
+          node.value.each { |val| val.format(q) }
+          q.text(" ")
         else
           q.text(" ")
           node.value.format(q)

--- a/lib/syntax_tree/css/format.rb
+++ b/lib/syntax_tree/css/format.rb
@@ -108,14 +108,20 @@ module SyntaxTree
 
       # Visit a Selectors::Combinator node.
       def visit_combinator(node)
-        node.value.format(q)
+        case node.value
+        when WhitespaceToken
+          q.text(" ")
+        else
+          q.text(" ")
+          node.value.format(q)
+          q.text(" ")
+        end
       end
 
       # Visit a Selectors::ComplexSelector node.
       def visit_complex_selector(node)
         q.group do
           node.child_nodes.each_with_index do |child_node, j|
-            q.text(" ") unless j == 0
             child_node.format(q)
           end
         end

--- a/lib/syntax_tree/css/pretty_print.rb
+++ b/lib/syntax_tree/css/pretty_print.rb
@@ -423,7 +423,7 @@ module SyntaxTree
 
       # Visit a Selectors::Combinator node.
       def visit_combinator(node)
-        token("combinator") do
+        token(node.class::PP_NAME) do
           q.breakable
           q.pp(node.value)
         end

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -128,15 +128,23 @@ module SyntaxTree
         end
 
         it "parses a complex selector" do
-          actual = parse_selectors("section>table")
+          actual = parse_selectors("a b > c + d ~ e || f")
 
           assert_pattern do
             actual => [
               Selectors::ComplexSelector[
                 child_nodes: [
-                  Selectors::TypeSelector[value: { name: { value: "section" } }],
-                  Selectors::Combinator[value: { value: ">" }],
-                  Selectors::TypeSelector[value: { name: { value: "table" } }]
+                  Selectors::TypeSelector[value: { name: { value: "a" } }],
+                  Selectors::DescendantCombinator,
+                  Selectors::TypeSelector[value: { name: { value: "b" } }],
+                  Selectors::ChildCombinator,
+                  Selectors::TypeSelector[value: { name: { value: "c" } }],
+                  Selectors::NextSiblingCombinator,
+                  Selectors::TypeSelector[value: { name: { value: "d" } }],
+                  Selectors::SubsequentSiblingCombinator,
+                  Selectors::TypeSelector[value: { name: { value: "e" } }],
+                  Selectors::ColumnSiblingCombinator,
+                  Selectors::TypeSelector[value: { name: { value: "f" } }],
                 ]
               ]
             ]

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -251,6 +251,13 @@ module SyntaxTree
               ".outer section.foo > table.bar tr",
             )
           end
+
+          it "handles all the combinators" do
+            assert_selector_format(
+              "a b > c + d ~ e || f",
+              "a b > c + d ~ e || f",
+            )
+          end
         end
 
         private

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -185,6 +185,7 @@ module SyntaxTree
               Selectors::ComplexSelector[
                 child_nodes: [
                   Selectors::TypeSelector[value: { name: { value: "section" } }],
+                  Selectors::Combinator[value: { value: " " }],
                   Selectors::TypeSelector[value: { name: { value: "table" } }],
                 ]
               ]
@@ -202,6 +203,7 @@ module SyntaxTree
                   Selectors::TypeSelector[value: { name: { value: "section" } }],
                   Selectors::Combinator[value: { value: ">" }],
                   Selectors::TypeSelector[value: { name: { value: "table" } }],
+                  Selectors::Combinator[value: { value: " " }],
                   Selectors::TypeSelector[value: { name: { value: "tr" } }]
                 ]
               ]


### PR DESCRIPTION
Making the descendant combinator explicit (where previously it was implicit by having two CompoundSelectors next to each other in a ComplexSelector) makes consuming the AST easier for visitors, and simplifies the selectors parser and its handling of whitespace.

This is an alternative to #60.