### PR TITLE
Parse pseudo-class function arguments

### DIFF
--- a/lib/syntax_tree/css/format.rb
+++ b/lib/syntax_tree/css/format.rb
@@ -100,6 +100,16 @@ module SyntaxTree
         node.value.format(q)
       end
 
+      # Visit a Selectors::PseudoClassFunction node.
+      def visit_pseudo_class_function(node)
+        q.text(node.name)
+        q.text("(")
+        q.seplist(node.arguments, -> { q.text(", ") }) do |selector|
+          selector.format(q)
+        end
+        q.text(")")
+      end
+
       # Visit a Selectors::PseudoElementSelector node.
       def visit_pseudo_element_selector(node)
         q.text(":")
@@ -127,7 +137,6 @@ module SyntaxTree
           node.child_nodes.each do |node_|
             node_.format(q)
           end
-          # TODO: pseudo-elements
         end
       end
 

--- a/lib/syntax_tree/css/pretty_print.rb
+++ b/lib/syntax_tree/css/pretty_print.rb
@@ -380,10 +380,19 @@ module SyntaxTree
           q.breakable
           q.pp(node.name)
 
+          q.breakable
+          q.text("(arguments")
+
           if node.arguments.any?
-            q.breakable
-            q.seplist(node.arguments) { |argument| q.pp(argument) }
+            q.nest(2) do
+              q.breakable
+              q.seplist(node.arguments) { |argument| q.pp(argument) }
+            end
+
+            q.breakable("")
           end
+
+          q.text(")")
         end
       end
 
@@ -443,7 +452,10 @@ module SyntaxTree
       def visit_compound_selector(node)
         token("compound-selector") do
           q.breakable
-          q.pp(node.type)
+          token("type") do
+            q.breakable
+            q.pp(node.type)
+          end
 
           q.breakable
           q.text("(subclasses")

--- a/lib/syntax_tree/css/selectors.rb
+++ b/lib/syntax_tree/css/selectors.rb
@@ -509,7 +509,8 @@ module SyntaxTree
           PseudoClassSelector.new(value: consume(IdentToken))
         in Function
           node = consume(Function)
-          function = PseudoClassFunction.new(name: node.name, arguments: node.value)
+          arguments = Selectors.new(node.value).parse
+          function = PseudoClassFunction.new(name: node.name, arguments: arguments)
           PseudoClassSelector.new(value: function)
         else
           raise MissingTokenError, "Expected pseudo class selector to produce something"

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -253,6 +253,13 @@ module SyntaxTree
             )
           end
 
+          it "with a pseudo-class function" do
+            assert_selector_format(
+              ".flex:not(div, span.wide, .hidden)",
+              ".flex:not(div, span.wide, .hidden)",
+            )
+          end
+
           it "with class selectors" do
             assert_selector_format(
               "div.flex.text-xl",

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -82,7 +82,7 @@ module SyntaxTree
           end
         end
 
-        it "parses a compound selector with a pseudo-class" do
+        it "parses a compound selector with a pseudo-class selector" do
           actual = parse_selectors("div.flex:hover")
 
           assert_pattern do
@@ -92,6 +92,33 @@ module SyntaxTree
                 subclasses: [
                   Selectors::ClassSelector[value: { value: "flex" }],
                   Selectors::PseudoClassSelector[value: { value: "hover" }],
+                ],
+              ]
+            ]
+          end
+        end
+
+        it "parses a compound selector with a pseudo-class function" do
+          actual = parse_selectors(".flex:not(div, span.wide, .hidden)")
+
+          assert_pattern do
+            actual => [
+              Selectors::CompoundSelector[
+                type: nil,
+                subclasses: [
+                  Selectors::ClassSelector[value: { value: "flex" }],
+                  Selectors::PseudoClassSelector[
+                    value: Selectors::PseudoClassFunction[
+                      name: "not",
+                      arguments: [
+                        Selectors::TypeSelector[value: { name: { value: "div" } }],
+                        Selectors::CompoundSelector[
+                          Selectors::TypeSelector[value: { name: { value: "span" } }],
+                          Selectors::ClassSelector[value: { value: "wide" }],
+                        ],
+                      ],
+                    ],
+                  ],
                 ],
               ]
             ]
@@ -208,7 +235,6 @@ module SyntaxTree
             ]
           end
         end
-
       end
 
       describe "formatting" do


### PR DESCRIPTION
Previously, `PseudoClassFunction` arguments were simply a copy of the `Function` token arguments. So from a selector of `".flex:not(div, span.wide, .hidden)"`, the `not` function would have these arguments in the AST:

```
[(ident-token "div"),
 (comma-token),
 (whitespace-token " "),
 (ident-token "span"),
 (delim-token "."),
 (ident-token "wide"),
 (comma-token),
 (whitespace-token " "),
 (delim-token "."),
 (ident-token "hidden")]
```

Now the arguments are parsed, so that a `PseudoClassFunction` is represented fully in the AST as something like:

```
(pseudo-class-selector
  (pseudo-class-function
    "not"
    (arguments
      (type-selector (wqname (ident-token "div"))),
      (compound-selector
        (type (type-selector (wqname (ident-token "span"))))
        (subclasses
          (class-selector (ident-token "wide"))
        )
        (pseudo-elements)
      ),
      (class-selector (ident-token "hidden"))
    )
  )
)
```