### PR TITLE
Split up combinators logic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
       prettier_print (>= 1.2.0)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/lib/syntax_tree/css/format.rb
+++ b/lib/syntax_tree/css/format.rb
@@ -42,13 +42,13 @@ module SyntaxTree
         q.text(node.value)
       end
 
-      # Visit an IdentToken node.
-      def visit_ident_token(node)
+      # Visit a HashToken node.
+      def visit_hash_token(node)
         q.text(node.value)
       end
 
-      # Visit a HashToken node.
-      def visit_hash_token(node)
+      # Visit an IdentToken node.
+      def visit_ident_token(node)
         q.text(node.value)
       end
 
@@ -70,16 +70,58 @@ module SyntaxTree
         end
       end
 
+      # Visit a Selectors::SubsequentSiblingCombinator node.
+      def visit_subsequent_sibling_combinator(node)
+        q.text(" ")
+        node.value.format(q)
+        q.text(" ")
+      end
+
       #-------------------------------------------------------------------------
       # Selector nodes
       #-------------------------------------------------------------------------
 
-      # Visit a Selectors::TypeSelector node.
-      def visit_type_selector(node)
+      # Visit a Selectors::ChildCombinator node.
+      def visit_child_combinator(node)
+        q.text(" ")
+        node.value.format(q)
+        q.text(" ")
+      end
+
+      # Visit a Selectors::ClassSelector node.
+      def visit_class_selector(node)
+        q.text(".")
+        node.value.format(q)
+      end
+
+      # Visit a Selectors::ColumnSiblingCombinator node.
+      def visit_column_sibling_combinator(node)
+        q.text(" ")
+        node.value.each { |value| value.format(q) }
+        q.text(" ")
+      end
+
+      # Visit a Selectors::ComplexSelector node.
+      def visit_complex_selector(node)
         q.group do
-          node.prefix.format(q) if node.prefix
-          node.value.format(q)
+          node.child_nodes.each do |child_node|
+            child_node.format(q)
+          end
         end
+      end
+
+      # Visit a Selectors::CompoundSelector node.
+      def visit_compound_selector(node)
+        q.group do
+          node.child_nodes.each do |child_node|
+            child_node.format(q)
+          end
+        end
+      end
+
+      # Visit a Selectors::DescendantCombinator node.
+      def visit_descendant_combinator(node)
+        q.text(" ")
       end
 
       # Visit a Selectors::IdSelector node.
@@ -88,10 +130,19 @@ module SyntaxTree
         node.value.format(q)
       end
 
-      # Visit a Selectors::ClassSelector node.
-      def visit_class_selector(node)
-        q.text(".")
+      # Visit a Selectors::NextSiblingCombinator node.
+      def visit_next_sibling_combinator(node)
+        q.text(" ")
         node.value.format(q)
+        q.text(" ")
+      end
+
+      # Visit a Selectors::TypeSelector node.
+      def visit_type_selector(node)
+        q.group do
+          node.prefix&.format(q)
+          node.value.format(q)
+        end
       end
 
       # Visit a Selectors::PseudoClassSelector node.
@@ -116,42 +167,9 @@ module SyntaxTree
         node.value.format(q)
       end
 
-      # Visit a Selectors::Combinator node.
-      def visit_combinator(node)
-        case node.value
-        when WhitespaceToken
-          q.text(" ")
-        when Array
-          q.text(" ")
-          node.value.each { |val| val.format(q) }
-          q.text(" ")
-        else
-          q.text(" ")
-          node.value.format(q)
-          q.text(" ")
-        end
-      end
-
-      # Visit a Selectors::ComplexSelector node.
-      def visit_complex_selector(node)
-        q.group do
-          node.child_nodes.each_with_index do |child_node, j|
-            child_node.format(q)
-          end
-        end
-      end
-
-      # Visit a Selectors::CompoundSelector node.
-      def visit_compound_selector(node)
-        q.group do
-          node.child_nodes.each do |node_|
-            node_.format(q)
-          end
-        end
-      end
-
+      # Visit a Selectors::WqName node.
       def visit_wqname(node)
-        node.prefix.format(q) if node.prefix
+        node.prefix&.format(q)
         node.name.format(q)
       end
     end

--- a/lib/syntax_tree/css/pretty_print.rb
+++ b/lib/syntax_tree/css/pretty_print.rb
@@ -350,89 +350,17 @@ module SyntaxTree
       # Selector nodes
       #-------------------------------------------------------------------------
 
-      # Visit a Selectors::ClassSelector node.
-      def visit_class_selector(node)
-        token("class-selector") do
+      # Visit a Selectors::ChildCombinator node.
+      def visit_child_combinator(node)
+        token("child-combinator") do
           q.breakable
           q.pp(node.value)
         end
       end
 
-      # Visit a Selectors::IdSelector node.
-      def visit_id_selector(node)
-        token("id-selector") do
-          q.breakable
-          q.pp(node.value)
-        end
-      end
-
-      # Visit a Selectors::PseudoClassSelector node.
-      def visit_pseudo_class_selector(node)
-        token("pseudo-class-selector") do
-          q.breakable
-          q.pp(node.value)
-        end
-      end
-
-      # Visit a Selectors::PseudoClassFunction node.
-      def visit_pseudo_class_function(node)
-        token("pseudo-class-function") do
-          q.breakable
-          q.pp(node.name)
-
-          q.breakable
-          q.text("(arguments")
-
-          if node.arguments.any?
-            q.nest(2) do
-              q.breakable
-              q.seplist(node.arguments) { |argument| q.pp(argument) }
-            end
-
-            q.breakable("")
-          end
-
-          q.text(")")
-        end
-      end
-
-      # Visit a Selectors::PseudoElementSelector node.
-      def visit_pseudo_element_selector(node)
-        token("pseudo-element-selector") do
-          q.breakable
-          q.pp(node.value)
-        end
-      end
-
-      # Visit a Selectors::TypeSelector node.
-      def visit_type_selector(node)
-        token("type-selector") do
-          if node.prefix
-            q.breakable
-            q.pp(node.prefix)
-          end
-
-          q.breakable
-          q.pp(node.value)
-        end
-      end
-
-      # Visit a Selectors::WqName node.
-      def visit_wqname(node)
-        token("wqname") do
-          if node.prefix
-            q.breakable
-            q.pp(node.prefix)
-          end
-
-          q.breakable
-          q.pp(node.name)
-        end
-      end
-
-      # Visit a Selectors::Combinator node.
-      def visit_combinator(node)
-        token(node.class::PP_NAME) do
+      # Visit a Selectors::ColumnSiblingCombinator node.
+      def visit_column_sibling_combinator(node)
+        token("column-sibling-combinator") do
           q.breakable
           q.pp(node.value)
         end
@@ -486,6 +414,110 @@ module SyntaxTree
           end
 
           q.text(")")
+        end
+      end
+
+      # Visit a Selectors::ClassSelector node.
+      def visit_class_selector(node)
+        token("class-selector") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::DescendantCombinator node.
+      def visit_descendant_combinator(node)
+        token("descendant-combinator") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::IdSelector node.
+      def visit_id_selector(node)
+        token("id-selector") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::NextSiblingCombinator node.
+      def visit_next_sibling_combinator(node)
+        token("next-sibling-combinator") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::PseudoClassSelector node.
+      def visit_pseudo_class_selector(node)
+        token("pseudo-class-selector") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::PseudoClassFunction node.
+      def visit_pseudo_class_function(node)
+        token("pseudo-class-function") do
+          q.breakable
+          q.pp(node.name)
+
+          q.breakable
+          q.text("(arguments")
+
+          if node.arguments.any?
+            q.nest(2) do
+              q.breakable
+              q.seplist(node.arguments) { |argument| q.pp(argument) }
+            end
+
+            q.breakable("")
+          end
+
+          q.text(")")
+        end
+      end
+
+      # Visit a Selectors::PseudoElementSelector node.
+      def visit_pseudo_element_selector(node)
+        token("pseudo-element-selector") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::SubsequentSiblingCombinator node.
+      def visit_subsequent_sibling_combinator(node)
+        token("subsequent-sibling-combinator") do
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::TypeSelector node.
+      def visit_type_selector(node)
+        token("type-selector") do
+          if node.prefix
+            q.breakable
+            q.pp(node.prefix)
+          end
+
+          q.breakable
+          q.pp(node.value)
+        end
+      end
+
+      # Visit a Selectors::WqName node.
+      def visit_wqname(node)
+        token("wqname") do
+          if node.prefix
+            q.breakable
+            q.pp(node.prefix)
+          end
+
+          q.breakable
+          q.pp(node.name)
         end
       end
 

--- a/lib/syntax_tree/css/visitor.rb
+++ b/lib/syntax_tree/css/visitor.rb
@@ -129,11 +129,14 @@ module SyntaxTree
       # Selector nodes
       #-------------------------------------------------------------------------
 
+      # Visit a Selectors::ChildCombinator node.
+      alias visit_child_combinator visit_child_nodes
+
       # Visit a Selectors::ClassSelector node.
       alias visit_class_selector visit_child_nodes
 
-      # Visit a Selectors::Combinator node.
-      alias visit_combinator visit_child_nodes
+      # Visit a Selectors::ColumnSiblingCombinator node.
+      alias visit_column_sibling_combinator visit_child_nodes
 
       # Visit a Selectors::ComplexSelector node.
       alias visit_complex_selector visit_child_nodes
@@ -141,8 +144,14 @@ module SyntaxTree
       # Visit a Selectors::CompoundSelector node.
       alias visit_compound_selector visit_child_nodes
 
+      # Visit a Selectors::DescendantCombinator node.
+      alias visit_descendant_combinator visit_child_nodes
+
       # Visit a Selectors::IdSelector node.
       alias visit_id_selector visit_child_nodes
+
+      # Visit a Selectors::NextSiblingCombinator node.
+      alias visit_next_sibling_combinator visit_child_nodes
 
       # Visit a Selectors::PseudoClassFunction node.
       alias visit_pseudo_class_function visit_child_nodes
@@ -152,6 +161,9 @@ module SyntaxTree
 
       # Visit a Selectors::PseudoElementSelector node.
       alias visit_pseudo_element_selector visit_child_nodes
+
+      # Visit a Selectors::SubsequentSiblingCombinator node.
+      alias visit_subsequent_sibling_combinator visit_child_nodes
 
       # Visit a Selectors::TypeSelector node.
       alias visit_type_selector visit_child_nodes

--- a/test/selectors_test.rb
+++ b/test/selectors_test.rb
@@ -317,8 +317,13 @@ module SyntaxTree
       private
 
       def parse_selectors(selectors)
-        css = selectors + " {}"
-        Parser.new(css).parse.rules.first.selectors
+        rule = Parser.new("#{selectors} {}").parse.rules.first
+
+        # Pretty-print and format so that we have coverage.
+        PP.pp(rule, +"")
+        PrettierPrint.format(+"", 80) { |q| rule.format(q) }
+
+        rule.selectors
       end
     end
   end


### PR DESCRIPTION
This PR does a couple of things.

1. Splits up the visit methods for combinators.
2. Formats and pretty-prints in the selectors test to add some coverage.
3. Splits up the combinators parsing into individual methods.